### PR TITLE
Replace print statement in fastica() with warning

### DIFF
--- a/sklearn/decomposition/fastica_.py
+++ b/sklearn/decomposition/fastica_.py
@@ -293,7 +293,7 @@ def fastica(X, n_components=None, algorithm="parallel", whiten=True,
         n_components = min(n, p)
     if (n_components > min(n, p)):
         n_components = min(n, p)
-        print("n_components is too large: it will be set to %s" % n_components)
+        warnings.warn('n_components is too large: it will be set to %s' % n_components)
 
     if whiten:
         # Centering the columns (ie the variables)


### PR DESCRIPTION
#### What does this implement/fix? Explain your changes.

I specifically have FastICA wrapped in a `with` block to ignore warnings, but still receive a print statement sometimes. FastICA seems to oddly have a print statement that functions as a warning, instead of using the `warnings.warn()` method.

Also the module is missing the following import:

```Python
from __future__ import print_function
```

So I'm pretty sure `print()` is a remnant of debug code